### PR TITLE
Activity groups documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The mapping below defines the six categories and lists the original DESCR_EROGAT
 | 1     | Tests        | LAB. ANALISI                                    |
 | 2     | Radiology     | RADIOLOGIA, NEURORADIOLOGIA                     |
 | 3     | Specialty_Diagnostics   | Cardio, Oculistico, Dermatologico |
-| 4     | Surgery_Resuscitation | Chirurgia, Rianimazione, Amb. Maxillo-Odontost. |
+| 4     | Surgery | Chirurgia, Rianimazione, Amb. Maxillo-Odontost. |
 | 5     | Oncology                | Oncologia Medica, Amb. Oncologico               |
 | 6     | Follow-Up  | Follow-up del paziente post acuto - ambulatorio           |
 

--- a/data/samples/grouping_overview.py
+++ b/data/samples/grouping_overview.py
@@ -3,7 +3,7 @@
 # Departments related to laboratory analysis and high-volume test data. 
 # This group makes up the majority of the dataset and is kept separate for clarity.
 # ==============================================
-LAB_ANALISI = [
+TESTS = [
     "LAB. ANALISI"
 ]
 
@@ -42,11 +42,11 @@ SPECIALTY_DIAGNOSTIC = [
 
 
 # ==============================================
-# 4. SURGICAL / VASCULAR / PROCEDURAL REPARTO
+# 4. SURGICAL / VASCULAR / ANESTESIA
 # Departments responsible for surgical interventions, vascular procedures, 
 # and anesthesia or resuscitation units.
 # ==============================================
-SURGICAL = [
+SURGERY = [
     "REPARTO AMBULATORIALE CHIRURGIA VASCOLARE",
     "REPARTO AMBULATORIALE CH.MAX.ODONTOST.",
     "REPARTO AMBULATORIALE ANESTESIA E RIANIMAZIONE"


### PR DESCRIPTION
### What it does
- adds description for the groupings & example table 
- adds a python file with thorough descriptions

### Notes:
 - I agree there should be some description of the different categories but it would take so much space of the ReadMe file and could easily become overwhelming, so I think it's better to keep it in separate file and just link to it. This way, someone who actually wants to see the full groupings can still access it, but the ReadMe doesn't become super long.
 - all activities should be post filtering, ie -  there's no activities with frequency below 10, and no PS Gen AO CASERTA or Eliots appearing but some double checking wouldn't hurt