### PR TITLE
Data Cleaning: Adjust Ambulance Acceptancy Waiting Time

### DIFF
--- a/data/raw/filtered_data.csv
+++ b/data/raw/filtered_data.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:431bdaddd80487e4e92ce108b38931de6948ab2944c8206280a9a7f97a7baea5
-size 213429996
+oid sha256:3fdc00dbe276d6d2bcd1f68ca77174977af0b0ca45907a1e053e95b2f3e41c31
+size 224848592

--- a/output/log.xes
+++ b/output/log.xes
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:878158edbb28fdbbe3f6ed9c422cd52bb3fce3e40fe83e06c88ad9232607a20c
-size 73429723
+oid sha256:826c0450f9efe97964c84a20cfba4467ea023e86e0bf15517f82bc068969afe4
+size 76920207


### PR DESCRIPTION
### Description

This PR adjusts event timestamps for cases where the arrival method contains the keyword “Ambulanza” (“ambulance”).

For these cases, we assume that initial case registration begins inside the ambulance before reaching the hospital.
Therefore:

ARRIVAL event duration is extended to include the time previously recorded as waiting for the ACCEPTANCY event.
After applying this transformation, opening the updated log in DISCO and filtering for ambulance arrivals shows an average ARRIVAL duration of ~30 minutes, which aligns with the expected pre-hospital activity.

The waiting time between TRIAGE_ENTRY and ACCEPTANCY for ambulance arrivals is normalized to 1 minute.